### PR TITLE
ci: modernize and harden the GitHub Actions workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,5 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Bumps the package version (patch) on every push to master and tags it.
+# The "Publish to NPM" workflow then runs on success and publishes that version.
 
 name: BumpVersion
 
@@ -10,35 +10,16 @@ on:
 
 jobs:
   bump-version:
-    name: 'Bump Version on release created'
+    name: 'Bump version on push to master'
     runs-on: ubuntu-latest
     outputs:
       new-version: ${{ steps.version-bump.outputs.newTag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: version-bump
-        uses:  'phips28/gh-action-bump-version@master'
+        uses: 'phips28/gh-action-bump-version@master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version-type:  'patch'
-          tag-prefix:  'v'
-
-  # create-release:
-  #   name: Create GitHub Release
-  #   runs-on: ubuntu-latest
-  #   needs: [bump-version]
-  #   if: needs.bump-version.outputs.new-version != ''
-    
-  # steps:
-  #   - name: New Version
-  #     env:
-  #       NEW_VERSION: ${{ steps.bump-version.outputs.new-version }}
-  #     run: echo "new version $NEW_VERSION"    
-  #   - name: Create Release
-  #     id: create-release
-  #     uses: marvinpinto/action-automatic-releases@latest
-  #     with:
-  #       automatic_release_tag: ${{ needs.bump-version.outputs.new-version }}
-  #       repo_token: ${{ github.token }}
-  #       prerelease: false
+          version-type: 'patch'
+          tag-prefix: 'v'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,30 @@
+# Builds Storybook on push to master and deploys it to the components host.
+
 name: Deploy Storybook
 
 on:
   workflow_dispatch: {}
   push:
-    branches: 
-      - master 
+    branches:
+      - master
 
 jobs:
   deploy-storybook:
     name: "Deploy Storybook"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          cache: 'npm'
       - run: npm install
-      - run: npm run-script build-storybook
+      - run: npm run build-storybook
 
-      - uses: wlixcc/SFTP-Deploy-Action@v1.0 
-        with:  
-          username: 'ubuntu'   #ssh user name
-          server: '${{ secrets.SERVER_IP }}' #引用之前创建好的secret
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }} #引用之前创建好的secret
-          local_path: './storybook-static/*'  # 对应我们项目build的文件夹路径
+      - uses: wlixcc/SFTP-Deploy-Action@v1.0
+        with:
+          username: 'ubuntu'
+          server: '${{ secrets.SERVER_IP }}'
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          local_path: './storybook-static/*'
           remote_path: '/home/ubuntu/components'
-
-

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,5 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Publishes the package to npm after BumpVersion has bumped the version on
+# master. Runs only when that bump actually succeeded.
 
 name: Publish to NPM
 
@@ -12,15 +12,21 @@ jobs:
   publish-npm:
     name: "Publish to npm"
     runs-on: ubuntu-latest
+    # Don't publish if the version bump failed (workflow_run also fires on failure).
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      # Check out master so we publish the version BumpVersion just committed.
+      - uses: actions/checkout@v4
         with:
-          node-version: 18
+          ref: master
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - run: npm run-script build
-      - name: Publish to NPM
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./package.json
+      # lint + test + build (produces dist/, which is what `files` publishes).
+      - run: npm run prepublish
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pre-check.yml
+++ b/.github/workflows/pre-check.yml
@@ -1,19 +1,23 @@
+# Sanity checks on every feature branch push: lint, test, build, and a
+# Storybook build to catch story breakage early.
+
 name: Pre Check
 
 on:
   push:
-    branches: 
+    branches:
       - 'feature/**'
 
 jobs:
-  deploy-storybook:
+  pre-check:
     name: "Pre Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          cache: 'npm'
       - run: npm install
-      - run: npm run-script prepublish
-      - run: npm run-script build-storybook
+      - run: npm run prepublish      # lint + test + build
+      - run: npm run build-storybook


### PR DESCRIPTION
- Upgrade actions/checkout@v2/3 -> v4 and actions/setup-node@v2-beta -> v4 across all workflows, with built-in npm caching.
- Standardize Node on 20.
- Publish to NPM: only run when BumpVersion succeeded; check out master so the just-bumped version is published; set registry-url and publish with plain `npm publish` + NODE_AUTH_TOKEN; run lint+test+build (prepublish) first.
- Drop the malformed commented-out create-release block from BumpVersion.

The recent publish E404 is a credential issue: NPM_TOKEN must be a valid npm automation token with publish access to miever_ui. This hardens the pipeline but does not replace that secret.