### PR TITLE
chore(release): lift version to 0.4.0 to clear reserved version numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miever_ui",
-  "version": "0.2.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miever_ui",
-      "version": "0.2.2",
+      "version": "0.4.0",
       "license": "MPL-2.0 license",
       "dependencies": {
         "@emotion/react": "^11.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miever_ui",
-  "version": "0.2.2",
+  "version": "0.4.0",
   "private": false,
   "author": "Miever",
   "license": "MPL-2.0",


### PR DESCRIPTION
Versions 0.2.0–0.3.0 were published then unpublished in 2022–2023; npm permanently reserves used version numbers, so the auto-publish kept 404ing on 0.2.2 (and would on every patch up to 0.3.0). Move package version above the highest-ever-used (0.3.0). On merge the patch bump publishes 0.4.1, which is free.