### PR TITLE
a11y, 100% test coverage, docs & Card hover fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,109 @@
 # Miever UI
 
-Miever UI is a personal React Components Library which can provide plenty of UI components to enrich my web applications.
+A personal React component library: 30+ accessible, themeable UI components
+built with TypeScript and SCSS, shipped as tree-shakeable ESM/CJS with full type
+definitions. It powers [miever.net](https://miever.net).
 
-## 🧳Install
+**📖 Live component docs & playground:** [components.miever.net](https://components.miever.net)
 
-```
+## Features
+
+- **30+ components** — layout, forms, navigation, feedback, data display.
+- **Light & dark themes** out of the box via CSS custom properties.
+- **TypeScript-first** — strict types and `.d.ts` for every component.
+- **Accessible** — ARIA wiring, focus management in overlays, keyboard support.
+- **Dual ESM/CJS** builds with a single CSS bundle.
+
+## Install
+
+```bash
 npm i miever_ui
-```
-
-```
+# or
 yarn add miever_ui
 ```
 
-## 🛠Usage
+`react` and `react-dom` (v18) are peer dependencies — install them in your app.
 
+## Setup
+
+Import the stylesheet **once** at your app's entry point. Without it, components
+render unstyled:
+
+```ts
+import "miever_ui/style";
 ```
-import { Icon, Button } from "miever_ui";
+
+Then import components anywhere:
+
+```tsx
+import { Button, Icon } from "miever_ui";
 
 const App = () => (
-  <>
-    <Button
-        styleType="link"
-        onClick={() => window.open("https://github.com/Miever1")}
-    >
-        <Icon icon={["fab", "github"]} theme="primary" style={{ fontSize: "14px", cursor: "pointer" }}/>
-    </Button>
-  </>
+  <Button type="link" onClick={() => window.open("https://github.com/Miever1")}>
+    <Icon icon={["fab", "github"]} theme="primary" />
+    GitHub
+  </Button>
 );
 ```
 
+> Icons use [FontAwesome](https://fontawesome.com/) — the solid (`fas`) and
+> brand (`fab`) packs are bundled, so any icon name from those packs works.
 
+## Theming & dark mode
+
+Themes are driven by a `data-theme` attribute (`"light"` or `"dark"`) on a
+container element, which switches the underlying CSS custom properties:
+
+```tsx
+<div data-theme="dark">
+  <Button type="primary">Dark-themed button</Button>
+</div>
+```
+
+For a managed theme scope, use `ConfigProvider`, which sets the attribute and
+lets you override design tokens:
+
+```tsx
+import { ConfigProvider, Button } from "miever_ui";
+
+<ConfigProvider defaultTheme="dark" tokens={{ "--color-bg-primary": "#101418" }}>
+  <Button type="primary">Themed</Button>
+</ConfigProvider>;
+```
+
+Design tokens (colors, spacing, radii, breakpoints) are also exported for use in
+your own styles:
+
+```ts
+import { BRAND_COLORS, BREAKPOINTS, SPACE_SIZE } from "miever_ui";
+```
+
+## Components
+
+**Layout** · Box · Grid (Row/Col) · Divider · Section · PageHeader
+**Forms** · Button · Input · AutoComplete · Select · Checkbox · Radio · Switch
+**Navigation** · Menu · Breadcrumb · Pagination · Tabs
+**Feedback** · Alert · Message · Modal · Drawer · Tooltip · Progress · Spin · Skeleton
+**Data display** · Card · Avatar · Badge · Tag · Timeline · Typography · Icon
+**Utilities** · ConfigProvider · Transition · `useBreakpoint()` hook
+
+See [components.miever.net](https://components.miever.net) for the full API of
+each component, with interactive controls.
+
+## Development
+
+```bash
+npm install
+npm run storybook   # develop components interactively
+npm test            # unit tests
+npm run lint        # lint
+npm run build       # full build (types + bundle + css)
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for conventions, the component file
+structure, and how to develop against a local app (e.g. miever.net) via
+`npm link`.
+
+## License
+
+[MIT](./LICENSE)

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,4 +3,9 @@ module.exports = {
   verbose: true,
   preset: "ts-jest",
   testEnvironment: "jest-environment-jsdom",
+  // Stub style imports (e.g. rc-tooltip's bundled CSS) so jest can parse
+  // component modules that import .css/.scss directly.
+  moduleNameMapper: {
+    "\\.(css|scss|sass|less)$": "<rootDir>/jest.styleMock.cjs",
+  },
 };

--- a/jest.styleMock.cjs
+++ b/jest.styleMock.cjs
@@ -1,0 +1,2 @@
+// Empty stub used by jest's moduleNameMapper to ignore style imports in tests.
+module.exports = {};

--- a/src/Components/AutoComplete/AutoComplete.test.tsx
+++ b/src/Components/AutoComplete/AutoComplete.test.tsx
@@ -36,7 +36,7 @@ describe('AutoComplete Component', () => {
         const user = userEvent.setup();
         render(<AutoComplete {...defaultProps} />);
         
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         await user.type(input, 'a');
         
         expect(screen.getByText('Apple')).toBeInTheDocument();
@@ -49,11 +49,30 @@ describe('AutoComplete Component', () => {
         const user = userEvent.setup();
         render(<AutoComplete {...defaultProps} />);
         
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         await user.click(input);
         
         defaultProps.options.forEach(option => {
             expect(screen.getByText(option)).toBeInTheDocument();
         });
+    });
+
+    test('exposes combobox/listbox a11y wiring', async () => {
+        const user = userEvent.setup();
+        render(<AutoComplete {...defaultProps} />);
+
+        const input = screen.getByRole('combobox');
+        expect(input).toHaveAttribute('aria-autocomplete', 'list');
+        expect(input).toHaveAttribute('aria-expanded', 'false');
+
+        await user.click(input);
+        expect(input).toHaveAttribute('aria-expanded', 'true');
+        const listbox = screen.getByRole('listbox');
+        expect(input).toHaveAttribute('aria-controls', listbox.id);
+
+        await user.keyboard('{ArrowDown}');
+        const activeId = input.getAttribute('aria-activedescendant');
+        expect(activeId).toBeTruthy();
+        expect(document.getElementById(activeId as string)).toHaveAttribute('role', 'option');
     });
 });

--- a/src/Components/AutoComplete/AutoComplete.tsx
+++ b/src/Components/AutoComplete/AutoComplete.tsx
@@ -3,6 +3,7 @@ import React, {
     useRef,
     useMemo,
     useEffect,
+    useId,
     KeyboardEvent,
 } from 'react';
 import classNames from 'classnames';
@@ -60,6 +61,9 @@ const AutoComplete = <T,>({
     const [showOptions, setShowOptions] = useState(false);
     const [highlightIndex, setHighlightIndex] = useState(-1);
     const isSelecting = useRef(false);
+
+    const listboxId = useId();
+    const getOptionId = (index: number) => `${listboxId}-option-${index}`;
 
     useEffect(() => {
         setInputValue(String(value || ''));
@@ -165,13 +169,25 @@ const AutoComplete = <T,>({
                 placeholder={placeholder}
                 className={`${prefixCls}-input`}
                 disabled={disabled}
+                role="combobox"
+                aria-expanded={showOptions}
+                aria-autocomplete="list"
+                aria-controls={showOptions ? listboxId : undefined}
+                aria-activedescendant={
+                    showOptions && highlightIndex >= 0
+                        ? getOptionId(highlightIndex)
+                        : undefined
+                }
             />
             <Transition in={showOptions} timeout={200} animation="zoom-in-top" unmountOnExit>
-                <Box className={`${prefixCls}-options`}>
+                <Box className={`${prefixCls}-options`} role="listbox" id={listboxId}>
                     {filteredOptions.length > 0 ? (
                         filteredOptions.map((option, index) => (
                             <Box
                                 key={index}
+                                id={getOptionId(index)}
+                                role="option"
+                                aria-selected={highlightIndex === index}
                                 className={classNames(`${prefixCls}-option`, {
                                     highlight: highlightIndex === index,
                                 })}

--- a/src/Components/Box/Box.test.tsx
+++ b/src/Components/Box/Box.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Box from './Box';
+
+describe('Box Component', () => {
+    it('renders a div with the base class and children', () => {
+        const { getByText } = render(<Box>content</Box>);
+        const node = getByText('content');
+        expect(node).toBeInTheDocument();
+        expect(node.tagName).toBe('DIV');
+        expect(node).toHaveClass('miever-box');
+    });
+
+    it('merges a custom className', () => {
+        const { getByText } = render(<Box className="extra">x</Box>);
+        expect(getByText('x')).toHaveClass('miever-box', 'extra');
+    });
+
+    it('only sets display:flex when flexBox is enabled', () => {
+        const { getByText, rerender } = render(
+            <Box flexBox direction="column" justifyContent="center" alignItems="center">
+                flex
+            </Box>,
+        );
+        const node = getByText('flex');
+        expect(node).toHaveStyle({
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+        });
+
+        rerender(<Box>block</Box>);
+        expect(getByText('block').style.display).toBe('');
+    });
+
+    it('resolves numeric width/height to pixels', () => {
+        const { getByText } = render(
+            <Box width={200} height={100}>
+                size
+            </Box>,
+        );
+        expect(getByText('size')).toHaveStyle({ width: '200px', height: '100px' });
+    });
+
+    it('passes through string dimensions verbatim', () => {
+        const { getByText } = render(<Box width="50%">pct</Box>);
+        expect(getByText('pct')).toHaveStyle({ width: '50%' });
+    });
+
+    it('resolves a numeric padding via the 4px scale', () => {
+        const { getByText } = render(<Box padding={2}>pad</Box>);
+        expect(getByText('pad')).toHaveStyle({ padding: '8px' });
+    });
+
+    it('applies paddingX / paddingY when padding is not set', () => {
+        const { getByText } = render(
+            <Box paddingX={3} paddingY={1}>
+                axes
+            </Box>,
+        );
+        expect(getByText('axes')).toHaveStyle({
+            paddingLeft: '12px',
+            paddingRight: '12px',
+            paddingTop: '4px',
+            paddingBottom: '4px',
+        });
+    });
+
+    it('spreads arbitrary props (role, id, data-*) onto the element', () => {
+        const { getByRole } = render(
+            <Box role="listbox" id="box-id" data-testid="box">
+                spread
+            </Box>,
+        );
+        const node = getByRole('listbox');
+        expect(node).toHaveAttribute('id', 'box-id');
+        expect(node).toHaveAttribute('data-testid', 'box');
+    });
+
+    it('forwards a ref to the root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Box ref={ref}>ref</Box>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+});

--- a/src/Components/Card/_style.scss
+++ b/src/Components/Card/_style.scss
@@ -12,8 +12,12 @@
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-a.miever-card {
+a.miever-card,
+a.miever-card:hover,
+a.miever-card:focus {
     color: inherit;
+    /* Beat the global `a:hover` underline (a card link is a surface, not text). */
+    text-decoration: none;
 }
 
 /* ── Surface variants ─────────────────────────────────────────────── */

--- a/src/Components/Drawer/Drawer.tsx
+++ b/src/Components/Drawer/Drawer.tsx
@@ -1,8 +1,9 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent, useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
 
 import { getPrefixCls } from '../../Utils/getPrefixCls';
+import { useFocusTrap } from '../../Utils/useFocusTrap';
 import Icon from '../Icon';
 import { DrawerProps } from './interface';
 
@@ -33,6 +34,10 @@ const Drawer: FunctionComponent<DrawerProps> = ({
     className,
     style,
 }) => {
+    const panelRef = useRef<HTMLDivElement>(null);
+    const titleId = useId();
+    useFocusTrap(panelRef, open);
+
     useEffect(() => {
         if (!open) return;
         const onKeyDown = (e: KeyboardEvent) => {
@@ -59,14 +64,19 @@ const Drawer: FunctionComponent<DrawerProps> = ({
                 onClick={maskClosable ? onClose : undefined}
             />
             <div
+                ref={panelRef}
                 className={classNames(prefixCls, `${prefixCls}-${placement}`, className)}
                 style={{ ...panelStyle, ...style }}
                 role="dialog"
                 aria-modal="true"
+                aria-labelledby={title ? titleId : undefined}
+                tabIndex={-1}
             >
                 {(title || closable) && (
                     <div className={`${prefixCls}-header`}>
-                        <div className={`${prefixCls}-title`}>{title}</div>
+                        <div className={`${prefixCls}-title`} id={titleId}>
+                            {title}
+                        </div>
                         {closable && (
                             <button
                                 type="button"

--- a/src/Components/Icon/Icon.test.tsx
+++ b/src/Components/Icon/Icon.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Icon from './Icon';
+import { BRAND_COLORS } from '../../Designs';
+
+describe('Icon Component', () => {
+    it('renders a FontAwesome svg with the base class', () => {
+        const { container } = render(<Icon icon="coffee" />);
+        const svg = container.querySelector('svg');
+        expect(svg).toBeInTheDocument();
+        expect(svg).toHaveClass('miever-icon');
+        // FontAwesome resolves "coffee" to its canonical name "mug-saucer".
+        expect(svg).toHaveAttribute('data-icon', 'mug-saucer');
+    });
+
+    it('merges a custom className', () => {
+        const { container } = render(<Icon icon="coffee" className="extra" />);
+        expect(container.querySelector('svg')).toHaveClass('miever-icon', 'extra');
+    });
+
+    it('applies a theme class and brand colour', () => {
+        const { container } = render(<Icon icon="coffee" theme="primary" />);
+        const svg = container.querySelector('svg') as SVGElement;
+        expect(svg).toHaveClass('miever-icon-primary');
+        expect(svg).toHaveStyle({ color: BRAND_COLORS.primary });
+    });
+
+    it('does not add theme colour when no theme is given', () => {
+        const { container } = render(<Icon icon="coffee" />);
+        const svg = container.querySelector('svg') as SVGElement;
+        expect(svg.style.color).toBe('');
+    });
+});

--- a/src/Components/Input/Input.test.tsx
+++ b/src/Components/Input/Input.test.tsx
@@ -35,4 +35,27 @@ describe("Input Component", () => {
         expect(testNode).toHaveClass('miever-input-size-lg');
         expect(smallTestNode).toHaveClass('miever-input-size-sm');
     });
+
+    it("associates a rendered label with the input via htmlFor", () => {
+        const wrapper = render(<Input {...defaultProps} label="Email" placeholder="email" />);
+        // getByLabelText resolves the input through the label association.
+        const input = wrapper.getByLabelText('Email') as HTMLInputElement;
+        expect(input).toBeInTheDocument();
+        expect(input).toHaveClass('miever-input-inner');
+        const label = wrapper.getByText('Email');
+        expect(label).toHaveAttribute('for', input.id);
+        expect(input.id).toBeTruthy();
+    });
+
+    it("respects a caller-supplied id for the label association", () => {
+        const wrapper = render(<Input {...defaultProps} id="custom-id" label="Name" placeholder="name" />);
+        const input = wrapper.getByLabelText('Name') as HTMLInputElement;
+        expect(input.id).toBe('custom-id');
+    });
+
+    it("renders no label element when label is omitted", () => {
+        const wrapper = render(<Input {...defaultProps} placeholder="no-label" />);
+        expect(wrapper.container.querySelector('.miever-input-label')).not.toBeInTheDocument();
+        expect(wrapper.container.querySelector('.miever-input-field')).not.toBeInTheDocument();
+    });
 });

--- a/src/Components/Input/Input.tsx
+++ b/src/Components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 import classNames from 'classnames';
 
 import { getPrefixCls } from '../../Utils/getPrefixCls';
@@ -19,14 +19,18 @@ const prefixCls = getPrefixCls('input');
  * ```
  */
 const Input = forwardRef<HTMLInputElement, NativeInputProps>(
-    ({ className, size, disabled, style, icon, ...restProps }, ref) => {
-        const classes = classNames(`${prefixCls}-wrapper`, className, {
+    ({ className, size, disabled, style, icon, label, id, ...restProps }, ref) => {
+        const generatedId = useId();
+        // Only allocate an id when we actually need one to link a <label>.
+        const inputId = id ?? (label ? generatedId : undefined);
+
+        const classes = classNames(`${prefixCls}-wrapper`, !label && className, {
             [`${prefixCls}-size-${size}`]: size,
             disabled,
         });
 
-        return (
-            <div className={classes} style={style}>
+        const field = (
+            <div className={classes} style={label ? undefined : style}>
                 {icon && (
                     <span className={`${prefixCls}-icon`}>
                         <Icon icon={icon} size={size === 'lg' ? 'lg' : 'sm'} />
@@ -34,10 +38,22 @@ const Input = forwardRef<HTMLInputElement, NativeInputProps>(
                 )}
                 <input
                     ref={ref}
+                    id={inputId}
                     disabled={disabled}
                     className={`${prefixCls}-inner`}
                     {...(restProps as React.InputHTMLAttributes<HTMLInputElement>)}
                 />
+            </div>
+        );
+
+        if (!label) return field;
+
+        return (
+            <div className={classNames(`${prefixCls}-field`, className)} style={style}>
+                <label className={`${prefixCls}-label`} htmlFor={inputId}>
+                    {label}
+                </label>
+                {field}
             </div>
         );
     },

--- a/src/Components/Input/_style.scss
+++ b/src/Components/Input/_style.scss
@@ -1,5 +1,20 @@
 @use '../../Styles/variables' as inputVars;
 
+.miever-input-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    width: 100%;
+}
+
+.miever-input-label {
+    font-family: inputVars.$input-font-family;
+    font-size: inputVars.$input-font-size-sm;
+    font-weight: 500;
+    line-height: inputVars.$input-line-height;
+    color: inputVars.$input-color;
+}
+
 .miever-input-wrapper {
     display: flex;
     width: 100%;

--- a/src/Components/Input/interface.ts
+++ b/src/Components/Input/interface.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes, ReactNode } from 'react';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export type InputSizes = 'sm' | 'md' | 'lg';
@@ -10,6 +10,12 @@ export interface InputProps {
     disabled?: boolean;
     /** Optional trailing FontAwesome icon */
     icon?: IconProp;
+    /**
+     * Optional visible label rendered as a `<label>` associated with the input
+     * via `htmlFor`. When omitted, no label element is rendered — pass
+     * `aria-label` instead for an accessible name on a label-less field.
+     */
+    label?: ReactNode;
 }
 
 export type NativeInputProps = InputProps & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;

--- a/src/Components/Modal/Modal.test.tsx
+++ b/src/Components/Modal/Modal.test.tsx
@@ -44,4 +44,48 @@ describe('Modal Component', () => {
         fireEvent.click(document.querySelector('.miever-modal-mask') as HTMLElement);
         expect(onClose).toHaveBeenCalled();
     });
+
+    it('labels the dialog with the title via aria-labelledby', () => {
+        render(
+            <Modal open title="Confirm delete">
+                body
+            </Modal>
+        );
+        const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+        const labelledBy = dialog.getAttribute('aria-labelledby');
+        expect(labelledBy).toBeTruthy();
+        const title = document.getElementById(labelledBy as string);
+        expect(title).toHaveTextContent('Confirm delete');
+    });
+
+    it('omits aria-labelledby when there is no title', () => {
+        render(<Modal open>body</Modal>);
+        const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+        expect(dialog).not.toHaveAttribute('aria-labelledby');
+    });
+
+    it('traps initial focus inside the dialog and restores it on close', () => {
+        const trigger = document.createElement('button');
+        document.body.appendChild(trigger);
+        trigger.focus();
+        expect(document.activeElement).toBe(trigger);
+
+        const { rerender } = render(
+            <Modal open title="t">
+                body
+            </Modal>
+        );
+        const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+        // Focus moved into the dialog (to the first focusable child or the dialog itself).
+        expect(dialog.contains(document.activeElement)).toBe(true);
+
+        rerender(
+            <Modal open={false} title="t">
+                body
+            </Modal>
+        );
+        // Focus returns to the element that opened the modal.
+        expect(document.activeElement).toBe(trigger);
+        document.body.removeChild(trigger);
+    });
 });

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent, useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
 
 import { getPrefixCls } from '../../Utils/getPrefixCls';
+import { useFocusTrap } from '../../Utils/useFocusTrap';
 import Button from '../Button';
 import Icon from '../Icon';
 import { ModalProps } from './interface';
@@ -36,6 +37,10 @@ const Modal: FunctionComponent<ModalProps> = ({
     className,
     style,
 }) => {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const titleId = useId();
+    useFocusTrap(dialogRef, open);
+
     useEffect(() => {
         if (!open) return;
         const onKeyDown = (e: KeyboardEvent) => {
@@ -67,14 +72,23 @@ const Modal: FunctionComponent<ModalProps> = ({
                 className={`${prefixCls}-mask`}
                 onClick={maskClosable ? onClose : undefined}
             />
-            <div className={`${prefixCls}-wrap`} role="dialog" aria-modal="true">
+            <div
+                ref={dialogRef}
+                className={`${prefixCls}-wrap`}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={title ? titleId : undefined}
+                tabIndex={-1}
+            >
                 <div
                     className={classNames(`${prefixCls}`, className)}
                     style={{ width, ...style }}
                 >
                     {(title || closable) && (
                         <div className={`${prefixCls}-header`}>
-                            <div className={`${prefixCls}-title`}>{title}</div>
+                            <div className={`${prefixCls}-title`} id={titleId}>
+                                {title}
+                            </div>
                             {closable && (
                                 <button
                                     type="button"

--- a/src/Components/Progress/Progress.test.tsx
+++ b/src/Components/Progress/Progress.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Progress from './Progress';
+
+describe('Progress Component', () => {
+    it('renders a line progressbar with accessible value attributes', () => {
+        render(<Progress percent={70} />);
+        const bar = screen.getByRole('progressbar');
+        expect(bar).toHaveAttribute('aria-valuenow', '70');
+        expect(bar).toHaveAttribute('aria-valuemin', '0');
+        expect(bar).toHaveAttribute('aria-valuemax', '100');
+        expect(bar).toHaveStyle({ width: '70%' });
+    });
+
+    it('clamps the percentage to the 0–100 range', () => {
+        const { rerender } = render(<Progress percent={150} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+        rerender(<Progress percent={-20} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('shows the percentage label by default and hides it with showInfo={false}', () => {
+        const { rerender, container } = render(<Progress percent={42} />);
+        expect(container.querySelector('.miever-progress-info')).toHaveTextContent('42%');
+        rerender(<Progress percent={42} showInfo={false} />);
+        expect(container.querySelector('.miever-progress-info')).not.toBeInTheDocument();
+    });
+
+    it('applies status and type modifier classes', () => {
+        const { container } = render(<Progress percent={50} status="success" />);
+        const root = container.querySelector('.miever-progress');
+        expect(root).toHaveClass('miever-progress-line', 'miever-progress-success');
+    });
+
+    it('renders an svg circle for the circle type', () => {
+        const { container } = render(<Progress type="circle" percent={90} />);
+        expect(container.querySelector('.miever-progress-circle')).toBeInTheDocument();
+        expect(container.querySelector('svg')).toBeInTheDocument();
+        expect(container.querySelector('.miever-progress-circle-info')).toHaveTextContent('90%');
+    });
+
+    it('forwards a ref to the root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Progress ref={ref} percent={10} />);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+});

--- a/src/Components/Select/Select.test.tsx
+++ b/src/Components/Select/Select.test.tsx
@@ -76,4 +76,22 @@ describe('Select', () => {
         render(<Select ref={ref} options={options} />);
         expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
+
+    it('exposes combobox/listbox wiring for assistive tech', () => {
+        render(<Select options={options} placeholder="Pick" />);
+        const combo = screen.getByRole('combobox');
+        expect(combo).toHaveAttribute('aria-haspopup', 'listbox');
+        // controls is only present while open.
+        expect(combo).not.toHaveAttribute('aria-controls');
+
+        fireEvent.click(screen.getByText('Pick'));
+        const listbox = screen.getByRole('listbox');
+        expect(combo).toHaveAttribute('aria-controls', listbox.id);
+
+        // Highlighting an option points aria-activedescendant at its id.
+        fireEvent.keyDown(combo, { key: 'ArrowDown' });
+        const activeId = combo.getAttribute('aria-activedescendant');
+        expect(activeId).toBeTruthy();
+        expect(document.getElementById(activeId as string)).toHaveAttribute('role', 'option');
+    });
 });

--- a/src/Components/Select/Select.tsx
+++ b/src/Components/Select/Select.tsx
@@ -2,6 +2,7 @@ import React, {
     forwardRef,
     useCallback,
     useEffect,
+    useId,
     useImperativeHandle,
     useRef,
     useState,
@@ -53,6 +54,9 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
     ) => {
         const rootRef = useRef<HTMLDivElement>(null);
         useImperativeHandle(ref, () => rootRef.current as HTMLDivElement, []);
+
+        const listboxId = useId();
+        const getOptionId = (index: number) => `${listboxId}-option-${index}`;
 
         const [open, setOpen] = useState(false);
         const [internal, setInternal] = useState<SelectValue | undefined>(defaultValue);
@@ -157,6 +161,11 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
                 role="combobox"
                 aria-expanded={open}
                 aria-disabled={disabled}
+                aria-haspopup="listbox"
+                aria-controls={open ? listboxId : undefined}
+                aria-activedescendant={
+                    open && highlight >= 0 ? getOptionId(highlight) : undefined
+                }
                 tabIndex={disabled ? -1 : 0}
                 onKeyDown={handleKeyDown}
             >
@@ -187,15 +196,17 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
                 </div>
 
                 <Transition in={open} timeout={200} animation="zoom-in-top" unmountOnExit>
-                    <ul className={`${prefixCls}-dropdown`} role="listbox">
+                    <ul className={`${prefixCls}-dropdown`} role="listbox" id={listboxId}>
                         {options.length === 0 && (
                             <li className={`${prefixCls}-empty`}>{notFoundContent}</li>
                         )}
                         {options.map((option, index) => (
                             <li
                                 key={option.value}
+                                id={getOptionId(index)}
                                 role="option"
                                 aria-selected={option.value === selectedValue}
+                                aria-disabled={option.disabled || undefined}
                                 className={classNames(`${prefixCls}-option`, {
                                     [`${prefixCls}-option-selected`]:
                                         option.value === selectedValue,

--- a/src/Components/Tooltip/Tooltip.test.tsx
+++ b/src/Components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Tooltip from './Tooltip';
+
+describe('Tooltip Component', () => {
+    it('renders its trigger child', () => {
+        render(
+            <Tooltip overlay={<span>hint</span>} trigger={['click']}>
+                <button type="button">trigger</button>
+            </Tooltip>,
+        );
+        expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();
+    });
+
+    it('shows the overlay content when triggered', () => {
+        render(
+            <Tooltip overlay={<span>hint text</span>} trigger={['click']}>
+                <button type="button">open tip</button>
+            </Tooltip>,
+        );
+        expect(screen.queryByText('hint text')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'open tip' }));
+        expect(screen.getByText('hint text')).toBeInTheDocument();
+    });
+});

--- a/src/Components/Transition/Transition.test.tsx
+++ b/src/Components/Transition/Transition.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Transition from './Transition';
+
+describe('Transition Component', () => {
+    it('renders children while `in` is true', () => {
+        render(
+            <Transition in timeout={200} animation="zoom-in-top">
+                <div>visible</div>
+            </Transition>,
+        );
+        expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('unmounts children when `in` is false and unmountOnExit is set', () => {
+        render(
+            <Transition in={false} timeout={200} animation="zoom-in-top" unmountOnExit>
+                <div>hidden</div>
+            </Transition>,
+        );
+        expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+    });
+
+    it('wraps children in a Box when wrapper is true', () => {
+        const { container } = render(
+            <Transition in wrapper timeout={200} animation="zoom-in-top">
+                <span>wrapped</span>
+            </Transition>,
+        );
+        const box = container.querySelector('.miever-box');
+        expect(box).toBeInTheDocument();
+        expect(box).toHaveTextContent('wrapped');
+    });
+});

--- a/src/Utils/useFocusTrap.ts
+++ b/src/Utils/useFocusTrap.ts
@@ -1,0 +1,75 @@
+import { RefObject, useEffect } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const getFocusable = (container: HTMLElement): HTMLElement[] =>
+    Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement,
+    );
+
+/**
+ * Trap keyboard focus inside `containerRef` while `active` is true, and restore
+ * focus to whatever was focused beforehand when it deactivates.
+ *
+ * Used by overlay components (Modal, Drawer) so keyboard and screen-reader users
+ * stay within the dialog and land back where they started on close.
+ *
+ * - On activate: remembers the current `activeElement`, then moves focus to the
+ *   first focusable child (falling back to the container itself).
+ * - While active: `Tab` / `Shift+Tab` cycle within the container.
+ * - On deactivate/unmount: restores focus to the remembered element.
+ */
+export const useFocusTrap = (
+    containerRef: RefObject<HTMLElement>,
+    active: boolean,
+): void => {
+    useEffect(() => {
+        if (!active || typeof document === 'undefined') return;
+
+        const container = containerRef.current;
+        if (!container) return;
+
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+
+        const focusable = getFocusable(container);
+        (focusable[0] ?? container).focus();
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key !== 'Tab') return;
+            const items = getFocusable(container);
+            if (items.length === 0) {
+                e.preventDefault();
+                container.focus();
+                return;
+            }
+            const first = items[0];
+            const last = items[items.length - 1];
+            const activeEl = document.activeElement;
+
+            if (e.shiftKey) {
+                if (activeEl === first || !container.contains(activeEl)) {
+                    e.preventDefault();
+                    last.focus();
+                }
+            } else if (activeEl === last || !container.contains(activeEl)) {
+                e.preventDefault();
+                first.focus();
+            }
+        };
+
+        container.addEventListener('keydown', onKeyDown);
+        return () => {
+            container.removeEventListener('keydown', onKeyDown);
+            previouslyFocused?.focus?.();
+        };
+    }, [active, containerRef]);
+};
+
+export default useFocusTrap;


### PR DESCRIPTION
## Summary
A round of quality improvements to the component library — accessibility, test coverage, docs, and a hover fix. All additive; no breaking API changes.

## Changes
- **a11y** — New `useFocusTrap` util: Modal & Drawer trap focus, restore it on close, and label the dialog via `aria-labelledby`. Select & AutoComplete now expose full combobox/listbox semantics (`aria-haspopup` / `aria-controls` / `aria-activedescendant` + id-linked options). Input gains an optional `label` with automatic `htmlFor`.
- **Tests** — Cover the last 5 untested components (Box, Icon, Progress, Tooltip, Transition) → 100% component coverage. Add a jest style mock so rc-tooltip's bundled CSS no longer breaks the suite.
- **Docs** — Expand the README (required `miever_ui/style` import, theming / dark mode via `ConfigProvider`, component overview, Storybook links) and fix the usage example (`type`, not `styleType`).
- **fix(Card)** — Linked cards no longer underline their text on hover.

## Verification
`npm run lint` ✅ (0 errors) · `npm test` ✅ (35 suites / 171 tests) · `npm run build` ✅

## Follow-up
After merge, bump the version and publish to npm so miever.net can pick these up — notably the Modal/Drawer focus trap and the Card fix.